### PR TITLE
Fixes #8 - Rozwiązano problem z zapisem raportów HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ migrations/
 *.pdf
 output/
 !edumonitor_timestamp.log
-!logs\example_edumonitor_timestamp.log
+!logs/example_edumonitor_timestamp.log

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ migrations/
 *.pdf
 output/
 !edumonitor_timestamp.log
+!logs\example_edumonitor_timestamp.log

--- a/config/config_example.ini
+++ b/config/config_example.ini
@@ -1,17 +1,19 @@
-# config/config.ini
-# main configuration file
+## config/config.ini
+# Główny plik konfiguracyjny
 #
 [DEFAULT]
-LOG = logs/edumonitor.log
 DATE_FORMAT = %d.%m.%Y
 #
 # Możliwe wartości: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL_CONSOLE = WARNING
 LOG_LEVEL_FILE = INFO
+LOG = logs/edumonitor.log
 #
 #
 [OUTPUT]
-LISTS_DIR = output/lists/
+HTML_LISTS = output/lists/
+HTML_REPORTS = output/reports/
+#
 #
 [DATABASE]
 # URL do pobierania danych o pracownikach

--- a/logs/example_edumonitor_timestamp.log
+++ b/logs/example_edumonitor_timestamp.log
@@ -1,0 +1,30 @@
+2024-09-25 08:58:57,671 - INFO - Program EduMonitor został uruchomiony.
+2024-09-25 08:58:57,687 - INFO - Rozpoczęto strumieniowe wczytywanie pliku CSV
+2024-09-25 08:58:57,687 - INFO - Zakończono filtrowanie danych. Wczytano 46 poprawnych pracowników, odrzucono 0 wierszy.
+2024-09-25 08:58:57,687 - INFO - Rozpoczęto pobieranie danych z URL
+2024-09-25 08:58:57,987 - INFO - Pobrano 281 rekordów pracowników z bazy danych.
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: WAYNE
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: KENT
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: ROGERS
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: PARKER
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: DANVERS
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: STARK
+2024-09-25 08:58:57,987 - WARNING - Szkolenie przeterminowane dla: ROMANOFF
+2024-09-25 08:58:58,002 - WARNING - Szkolenie przeterminowane dla: BANNER
+2024-09-25 08:58:58,002 - WARNING - Szkolenie przeterminowane dla: ALLEN
+2024-09-25 08:58:58,002 - WARNING - Szkolenie przeterminowane dla: QUEEN
+2024-09-25 08:58:58,002 - WARNING - Szkolenie przeterminowane dla: PRINCE
+2024-09-25 08:58:58,002 - WARNING - Szkolenie przeterminowane dla: LUTHOR
+2024-09-25 08:58:58,005 - WARNING - Szkolenie przeterminowane dla: STRANGE
+2024-09-25 08:58:58,006 - WARNING - Szkolenie przeterminowane dla: LOGAN
+2024-09-25 08:58:58,006 - WARNING - Szkolenie przeterminowane dla: SUMMERS
+2024-09-25 08:58:58,006 - WARNING - Szkolenie przeterminowane dla: WILSON
+2024-09-25 08:58:58,007 - WARNING - Szkolenie przeterminowane dla: BLAKE
+2024-09-25 08:58:58,007 - INFO - Znaleziono 0 kadry zarządzającej, 0 kierowniczej, oraz 46 pracowników.
+2024-09-25 08:58:58,053 - INFO - Wyświetlono 29 pracowników dla grupy 'Pracownicy - Aktualne szkolenie'
+2024-09-25 08:58:58,062 - INFO - Wyświetlono 17 pracowników dla grupy 'Pracownicy - Szkolenie wygaśnie w ciągu 30 dni lub już wygasło'
+2024-09-25 08:58:58,072 - INFO - Brak pracowników w grupie 'Kadra Zarządzająca'.
+2024-09-25 08:58:58,072 - INFO - Brak pracowników w grupie 'Kadra Kierownicza'.
+2024-09-25 08:58:58,078 - INFO - Lista pracowników 'Pracownicy' zapisana w output/lists/
+2024-09-25 08:58:58,080 - INFO - Raport HTML wygenerowany: output/reports/
+2024-09-25 08:58:58,084 - INFO - Program EduMonitor został zakończony.

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -84,7 +84,13 @@ class ConfigLoader:
         """
         Pobiera ścieżkę do katalogu na listy HTML z pliku konfiguracyjnego.
         """
-        return self.get('OUTPUT', 'LISTS_DIR', fallback='output/lists/')
+        return self.get('OUTPUT', 'HTML_LISTS', fallback='output/lists/')
+
+    def get_output_reports_dir(self):
+        """
+        Pobiera ścieżkę do katalogu na raporty HTML z pliku konfiguracyjnego.
+        """
+        return self.get('OUTPUT', 'HTML_REPORTS', fallback='output/reports/')
 
     def _map_log_level(self, level):
         """

--- a/src/html_generator.py
+++ b/src/html_generator.py
@@ -12,7 +12,8 @@ logger = setup_logger()
 class HTMLReportGenerator:
     def __init__(self, config_file='config/config.ini'):
         self.config_loader = ConfigLoader(config_file)
-        self.output_dir = self.config_loader.get_output_lists_dir()
+        self.lists_dir = self.config_loader.get_output_lists_dir()  # Ścieżka do katalogu na listy
+        self.reports_dir = self.config_loader.get_output_reports_dir()  # Ścieżka do katalogu na raporty
         self.templates_dir = 'templates'
         self.employee_list_template = self.load_template('employee_list_template.html')
         self.company_report_template = self.load_template('employee_report_template.html')
@@ -40,7 +41,7 @@ class HTMLReportGenerator:
             return
 
         file_name = f"{group_name.lower().replace(' ', '_')}_lista.html"
-        file_path = os.path.join(self.output_dir, file_name)
+        file_path = os.path.join(self.lists_dir, file_name)  # Zapisywanie w katalogu lists
         html_content = self.employee_list_template.render(group_name=group_name, employees=employees)
 
         with open(file_path, 'w', encoding='utf-8') as f:
@@ -62,7 +63,7 @@ class HTMLReportGenerator:
         current_date = format_date(datetime.now(), "%d.%m.%Y")
 
         file_name = f"raport_wyszkolenia_{datetime.now().strftime('%Y-%m-%d')}.html"
-        file_path = os.path.join(self.output_dir, file_name)
+        file_path = os.path.join(self.reports_dir, file_name)  # Zapisywanie w katalogu reports
         html_content = self.company_report_template.render(
             valid_training=len(valid_training),
             soon_expiring=len(soon_expiring),

--- a/tests/test_HTMLReportGenerator.py
+++ b/tests/test_HTMLReportGenerator.py
@@ -9,11 +9,11 @@ from src.employee import Employee  # Zakładamy, że Employee istnieje w src.emp
 class TestHTMLReportGenerator(unittest.TestCase):
 
     @mock.patch('builtins.open', new_callable=mock.mock_open)  # Mockujemy otwieranie pliku
-    @mock.patch('src.html_generator.os.path.join', return_value='output/test_report.html')  # Mockujemy os.path.join
+    @mock.patch('src.html_generator.os.path.join', return_value='output/reports/test_report.html')  # Mockujemy os.path.join
     @mock.patch('src.html_generator.Template.render')  # Mockujemy renderowanie szablonu
     def test_generate_training_report(self, mock_render, mock_path_join, mock_open):
         """Test generowania raportu HTML o stanie szkoleń."""
-        
+
         # Przykładowi pracownicy
         employees = [
             Employee(
@@ -29,7 +29,7 @@ class TestHTMLReportGenerator(unittest.TestCase):
                 data_szkolenia=datetime(2023, 7, 5), wazne_do=datetime(2025, 7, 5)
             )
         ]
-        
+
         # Instancja klasy HTMLReportGenerator
         report_generator = HTMLReportGenerator()
 
@@ -37,19 +37,19 @@ class TestHTMLReportGenerator(unittest.TestCase):
         report_generator.generate_training_report(employees)
 
         # Sprawdzenie, czy plik został zapisany poprawnie
-        mock_open.assert_any_call('output/test_report.html', 'w', encoding='utf-8')
+        mock_open.assert_any_call('output/reports/test_report.html', 'w', encoding='utf-8')
 
         # Sprawdzenie, czy metoda render została wywołana z odpowiednimi danymi
         mock_render.assert_called_once_with(
             valid_training=2,  # Wszyscy pracownicy mają ważne szkolenia
             soon_expiring=0,  # Żaden z pracowników nie ma szkolenia kończącego się w ciągu 30 dni
-            expired=1,  # Żaden z pracowników nie ma przeterminowanego szkolenia
+            expired=1,  # Jeden pracownik ma przeterminowane szkolenie
             employees=employees,
             current_date=datetime.now().strftime("%d.%m.%Y")
         )
 
     @mock.patch('builtins.open', new_callable=mock.mock_open)  # Mockujemy otwieranie pliku
-    @mock.patch('src.html_generator.os.path.join', return_value='output/employee_list.html')  # Mockujemy os.path.join
+    @mock.patch('src.html_generator.os.path.join', return_value='output/lists/employee_list.html')  # Mockujemy os.path.join
     @mock.patch('src.html_generator.Template.render')  # Mockujemy renderowanie szablonu
     def test_generate_employee_list(self, mock_render, mock_path_join, mock_open):
         """Test generowania listy pracowników w formacie HTML."""
@@ -65,7 +65,7 @@ class TestHTMLReportGenerator(unittest.TestCase):
                 data_szkolenia=datetime(2024, 6, 15), wazne_do=datetime(2025, 6, 15)
             )
         ]
-        
+
         # Instancja klasy HTMLReportGenerator
         report_generator = HTMLReportGenerator()
 
@@ -73,7 +73,7 @@ class TestHTMLReportGenerator(unittest.TestCase):
         report_generator.generate_employee_list("Kadra kierownicza", employees)
 
         # Sprawdzenie, czy plik został zapisany poprawnie
-        mock_open.assert_any_call('output/employee_list.html', 'w', encoding='utf-8')
+        mock_open.assert_any_call('output/lists/employee_list.html', 'w', encoding='utf-8')
 
         # Sprawdzenie, czy metoda render została wywołana z odpowiednimi danymi
         mock_render.assert_called_once_with(


### PR DESCRIPTION
### Naprawy i zmiany:
- **Dodano nowe zmienne konfiguracyjne w pliku `config/config.ini`**:
  - `HTML_LISTS` dla katalogu, w którym zapisywane są listy pracowników w formacie HTML.
  - `HTML_REPORTS` dla katalogu, w którym zapisywane są raporty o stanie wyszkolenia pracowników w formacie HTML.
- **Aktualizacja modułu `HTMLReportGenerator`**:
  - Oddzielenie zapisywania list pracowników i raportów szkoleniowych do odpowiednich katalogów na podstawie zmiennych z pliku konfiguracyjnego.
  - Listy pracowników są teraz zapisywane w katalogu `output/lists/`, a raporty w katalogu `output/reports/`.
- **Aktualizacja testów**:
  - Zaktualizowano testy w pliku `tests/test_HTMLReportGenerator.py`, aby uwzględniały nowe ścieżki katalogów dla list i raportów.
  - Testy sprawdzają teraz poprawność generowania raportów i list HTML oraz poprawność ścieżek do plików.