### PR TITLE
Rozszerzenie raportu o podział na grupy zawodowe i statusy szkoleń

### DIFF
--- a/templates/employee_report_template.html
+++ b/templates/employee_report_template.html
@@ -9,8 +9,25 @@
 <body>
     <h1>Raport stanu wyszkolenia</h1>
     <p>Gdynia dnia {{ current_date }}</p>
+    <p>Stan osobowy FIRMA: {{ total_employees }}</p>
+
     <p>Liczba pracowników z ważnymi szkoleniami: {{ valid_training }}</p>
     <p>Liczba pracowników z wygasającymi szkoleniami: {{ soon_expiring }}</p>
     <p>Liczba pracowników z przeterminowanymi szkoleniami: {{ expired }}</p>
+
+    <h2>Kadra zarządzająca</h2>
+    <p>Liczba pracowników z ważnymi szkoleniami: {{ kadra_zarzadcza_summary.valid }}</p>
+    <p>Liczba pracowników z wygasającymi szkoleniami: {{ kadra_zarzadcza_summary.soon_expiring }}</p>
+    <p>Liczba pracowników z przeterminowanymi szkoleniami: {{ kadra_zarzadcza_summary.expired }}</p>
+
+    <h2>Kadra kierownicza</h2>
+    <p>Liczba pracowników z ważnymi szkoleniami: {{ kadra_kierownicza_summary.valid }}</p>
+    <p>Liczba pracowników z wygasającymi szkoleniami: {{ kadra_kierownicza_summary.soon_expiring }}</p>
+    <p>Liczba pracowników z przeterminowanymi szkoleniami: {{ kadra_kierownicza_summary.expired }}</p>
+
+    <h2>Pracownicy</h2>
+    <p>Liczba pracowników z ważnymi szkoleniami: {{ pracownicy_summary.valid }}</p>
+    <p>Liczba pracowników z wygasającymi szkoleniami: {{ pracownicy_summary.soon_expiring }}</p>
+    <p>Liczba pracowników z przeterminowanymi szkoleniami: {{ pracownicy_summary.expired }}</p>
 </body>
 </html>


### PR DESCRIPTION
Dodano szczegółowy podział raportu o stanie wyszkolenia na grupy zawodowe:
- Dodano podział pracowników na grupy: kadra zarządzająca, kadra kierownicza, pracownicy.
- Wygenerowano oddzielne statystyki dla każdej grupy: liczba pracowników z ważnymi, wygasającymi i przeterminowanymi szkoleniami.
- Zaktualizowano szablon HTML, aby wyświetlał te informacje.

Fixes #11