### PR TITLE
13 pobieranie nazwy firmy do raportu z pliku konfiguracyjnego

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # CHANGELOG
 
+## [v1.4.0] - 2024-09-25
+### Nowości:
+- **Dodano nowe zmienne konfiguracyjne** w pliku `config/config.ini`:
+  - `HTML_LISTS`: Ścieżka do katalogu, w którym zapisywane są listy pracowników w formacie HTML.
+  - `HTML_REPORTS`: Ścieżka do katalogu, w którym zapisywane są raporty o stanie wyszkolenia pracowników w formacie HTML.
+- **Flaga --test-csv**: Wprowadzono flagę `--test-csv`, która pozwala na szybkie testowanie programu za pomocą przykładowego pliku CSV z katalogu `tests/test_files/`.
+- **Testy jednostkowe**: Dodano kompleksowy zestaw testów jednostkowych obejmujących m.in.:
+  - Wczytywanie danych z plików CSV (`CSVLoader`).
+  - Porównywanie danych z pliku CSV z danymi z URL (`EmployeeManager`).
+  - Generowanie raportów HTML (`HTMLReportGenerator`).
+  - Wyświetlanie danych w konsoli (`TableDisplay`).
+  - Pobieranie danych z URL i obsługę wyjątków (`fetch_employee_data_from_url`).
+
+### Ulepszenia:
+- **Modularność kodu**: Przebudowano strukturę projektu, rozdzielając logikę na osobne moduły, takie jak `csv_loader`, `employee_management`, `html_generator`, `table_display`. To umożliwia łatwiejsze zarządzanie kodem i jego przyszłą rozbudowę.
+- **Poprawa logowania**: Dodano dedykowany moduł `logger_setup`, który konfiguruje logger na podstawie ustawień z pliku `config.ini`. Obsługiwane są różne poziomy logowania, a każde uruchomienie programu generuje plik logów z timestampem w nazwie.
+- **Obsługa wyjątków**: Lepsze zarządzanie błędami i wyjątkami dzięki dekoratorowi `@log_exceptions`, który automatycznie loguje nieoczekiwane błędy występujące podczas działania programu.
+- **Konfiguracja**: Wprowadzono klasę `ConfigLoader`, która ułatwia zarządzanie ustawieniami programu, takimi jak format dat, ścieżki do plików i ustawienia połączeń z bazą danych.
+
+### Poprawki:
+- **Poprawa loggera**: Upewniono się, że uchwyty loggera są prawidłowo zamykane, co eliminuje problemy z wyciekami zasobów (np. ostrzeżenia `ResourceWarning`).
+- **Poprawa obsługi wyjątków**: W funkcji `fetch_employee_data_from_url` wprowadzono lepszą obsługę błędów związanych z połączeniami (np. `ConnectionError`), timeoutami oraz błędami HTTP (404, 500).
+- **Elastyczne logowanie**: Dodano możliwość mockowania loggera w testach, co pozwala na wyciszenie zbędnych komunikatów i przyspieszenie testów.
+
+### Dokumentacja:
+- Zaktualizowano dokumentację, aby odzwierciedlała wszystkie zmiany wprowadzone w tej wersji, w tym nową strukturę modułów, konfigurację logowania oraz zarządzanie wyjątkami.
+- Dodano szczegółowe informacje dotyczące konfiguracji programu, w tym zarządzanie katalogami dla plików HTML i CSV oraz formatowanie dat.
+
 ## [v1.3.2] - 2024-09-25
 ### Naprawy i zmiany:
 - **Dodano nowe zmienne konfiguracyjne w pliku `config/config.ini`**:

--- a/config/config_example.ini
+++ b/config/config_example.ini
@@ -3,6 +3,7 @@
 #
 [DEFAULT]
 DATE_FORMAT = %d.%m.%Y
+COMPANY_NAME = Example Company
 #
 # Możliwe wartości: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL_CONSOLE = WARNING

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -104,3 +104,9 @@ class ConfigLoader:
             'CRITICAL': logging.CRITICAL
         }
         return log_levels.get(level, logging.INFO)
+    
+    def get_company_name(self):
+        """
+        Pobiera nazwę firmy z pliku konfiguracyjnego.
+        """
+        return self.get('DEFAULT', 'COMPANY_NAME', fallback='Example Company')

--- a/src/html_generator.py
+++ b/src/html_generator.py
@@ -59,7 +59,12 @@ class HTMLReportGenerator:
 
     @log_exceptions(logger)
     def generate_training_report(self, employees):
-        """Generuje raport HTML o stanie szkoleń z podziałem na grupy zawodowe."""
+        """
+        Generuje raport HTML o stanie szkoleń z podziałem na grupy zawodowe.
+        """
+
+        # Pobranie nazwy firmy z konfiguracji
+        company_name = self.config_loader.get_company_name()
 
         # Podsumowanie dla całej firmy
         valid_training, soon_expiring, expired = self._get_training_summary(employees)
@@ -95,6 +100,7 @@ class HTMLReportGenerator:
             expired = len(expired),
             total_employees = total_employees,
             current_date = current_date,
+            company_name = company_name,
             kadra_zarzadcza_summary = kadra_zarzadcza_summary,
             kadra_kierownicza_summary = kadra_kierownicza_summary,
             pracownicy_summary = pracownicy_summary

--- a/templates/employee_report_template.html
+++ b/templates/employee_report_template.html
@@ -9,7 +9,7 @@
 <body>
     <h1>Raport stanu wyszkolenia</h1>
     <p>Gdynia dnia {{ current_date }}</p>
-    <p>Stan osobowy FIRMA: {{ total_employees }}</p>
+    <p>Stan osobowy {{ company_name }}: {{ total_employees }}</p>
 
     <p>Liczba pracowników z ważnymi szkoleniami: {{ valid_training }}</p>
     <p>Liczba pracowników z wygasającymi szkoleniami: {{ soon_expiring }}</p>


### PR DESCRIPTION
- Zaktualizowano plik config.ini o klucz COMPANY_NAME, który przechowuje nazwę firmy.
- Dodano metodę w ConfigLoader do pobierania nazwy firmy.
- Zmodyfikowano metodę generate_training_report, aby przekazywała nazwę firmy do szablonu HTML.
- Zaktualizowano szablon HTML raportu, aby wyświetlał nazwę firmy zamiast statycznego tekstu 'FIRMA'.

Fixes #13 