### PR TITLE
Dodano dynamiczne pobieranie nazwy firmy z pliku konfiguracyjnego

### DIFF
--- a/config/config_example.ini
+++ b/config/config_example.ini
@@ -3,6 +3,7 @@
 #
 [DEFAULT]
 DATE_FORMAT = %d.%m.%Y
+COMPANY_NAME = Example Company
 #
 # Możliwe wartości: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL_CONSOLE = WARNING

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -104,3 +104,9 @@ class ConfigLoader:
             'CRITICAL': logging.CRITICAL
         }
         return log_levels.get(level, logging.INFO)
+    
+    def get_company_name(self):
+        """
+        Pobiera nazwę firmy z pliku konfiguracyjnego.
+        """
+        return self.get('DEFAULT', 'COMPANY_NAME', fallback='Example Company')

--- a/src/html_generator.py
+++ b/src/html_generator.py
@@ -59,7 +59,12 @@ class HTMLReportGenerator:
 
     @log_exceptions(logger)
     def generate_training_report(self, employees):
-        """Generuje raport HTML o stanie szkoleń z podziałem na grupy zawodowe."""
+        """
+        Generuje raport HTML o stanie szkoleń z podziałem na grupy zawodowe.
+        """
+
+        # Pobranie nazwy firmy z konfiguracji
+        company_name = self.config_loader.get_company_name()
 
         # Podsumowanie dla całej firmy
         valid_training, soon_expiring, expired = self._get_training_summary(employees)
@@ -95,6 +100,7 @@ class HTMLReportGenerator:
             expired = len(expired),
             total_employees = total_employees,
             current_date = current_date,
+            company_name = company_name,
             kadra_zarzadcza_summary = kadra_zarzadcza_summary,
             kadra_kierownicza_summary = kadra_kierownicza_summary,
             pracownicy_summary = pracownicy_summary

--- a/templates/employee_report_template.html
+++ b/templates/employee_report_template.html
@@ -9,7 +9,7 @@
 <body>
     <h1>Raport stanu wyszkolenia</h1>
     <p>Gdynia dnia {{ current_date }}</p>
-    <p>Stan osobowy FIRMA: {{ total_employees }}</p>
+    <p>Stan osobowy {{ company_name }}: {{ total_employees }}</p>
 
     <p>Liczba pracowników z ważnymi szkoleniami: {{ valid_training }}</p>
     <p>Liczba pracowników z wygasającymi szkoleniami: {{ soon_expiring }}</p>


### PR DESCRIPTION
- Zaktualizowano plik config.ini o klucz COMPANY_NAME, który przechowuje nazwę firmy.
- Dodano metodę w ConfigLoader do pobierania nazwy firmy.
- Zmodyfikowano metodę generate_training_report, aby przekazywała nazwę firmy do szablonu HTML.
- Zaktualizowano szablon HTML raportu, aby wyświetlał nazwę firmy zamiast statycznego tekstu 'FIRMA'.

resolved #13 