### PR TITLE
21 dodanie flagi generującej listy pracowników na szkolenia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## [Undefined] - 2024-09-26 no.3
+### Dodane
+- Dodano nową funkcjonalność generowania list w formacie HTML dla różnych grup zawodowych:
+  - Kadra zarządzająca
+  - Kadra kierownicza
+  - Pracownicy
+- Nowa metoda `generate_lists_for_all_groups` w klasie `HTMLListGenerator`, która automatycznie generuje osobne listy dla każdej grupy zawodowej.
+- Zaktualizowano flagę `--generate-training-lists`, aby umożliwiała generowanie osobnych plików HTML dla każdej grupy.
+- Rozdzielono logikę generowania list od głównej funkcji, przenosząc ją do klasy `HTMLListGenerator` w celu lepszej organizacji kodu.
+
+### Zmodyfikowane
+- Uproszczono logikę w pliku `edumonitor.py`, która teraz korzysta z nowej metody `generate_lists_for_all_groups` do generowania list pracowników.
+
+### Naprawione
+- Poprawiono logikę obsługi flag, aby można było łączyć flagi `--csv` z `--shell` lub `--generate-training-lists` w jednym uruchomieniu programu.
+
 ## [Undefined] - 2024-09-26 no.2
 ### Zmiany:
 - **Przeniesienie logiki przetwarzania argumentu CSV**: Funkcja odpowiedzialna za walidację i przetwarzanie pliku CSV została przeniesiona z `edumonitor.py` do modułu `arg_parser.py`. 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 ## Opis projektu
 EduMonitor to narzędzie do monitorowania szkoleń pracowników, które umożliwia przetwarzanie danych z plików CSV, porównywanie ich z danymi pobranymi z zewnętrznego URL oraz wyświetlanie wyników w konsoli w formie tabel. Program obsługuje również generowanie raportów i list pracowników w formacie HTML, dotyczących szkoleń, które wkrótce wygasną lub już wygasły.
 
+Dodatkowo program umożliwia generowanie osobnych list w formacie HTML dla różnych grup zawodowych, takich jak:
+
+- Kadra zarządzająca
+- Kadra kierownicza
+- Pracownicy
+
 ## Wymagania
 - Python 3.10 lub nowszy
 - `prettytable` (instalacja: `pip install prettytable`)
@@ -26,16 +32,29 @@ Program można uruchomić, używając flagi `--csv` . Aby wyniki były wyświetl
 ## Flagi i opcje
 - `--csv <ścieżka do pliku>`: Wczytuje dane z pliku CSV, przetwarza je oraz porównuje z danymi z bazy URL. Dane po przetworzeniu są zapisywane do pliku JSON w katalogu `input/`.
 - `--shell`: Wyświetla dane w konsoli w formie tabeli, po przetworzeniu pliku CSV i porównaniu z danymi z bazy URL.
+- `--generate-training-lists`: Generuje osobne listy w formacie HTML dla różnych grup zawodowych (kadra zarządzająca, kadra kierownicza, pracownicy), zapisując je w katalogu `output/lists/`.
 - `-h / --help`: Wyświetla pomoc dotyczącą dostępnych opcji.
 
 ## Funkcjonalności
 - **Wczytywanie i porównanie danych**: Program wczytuje pliki CSV zawierające informacje o pracownikach i ich szkoleniach, a następnie zapisuje te dane do formatu JSON. W trakcie przetwarzania, dane pracowników są automatycznie porównywane z danymi pobranymi z zewnętrznego URL, co umożliwia uzupełnienie informacji o stanowisku i adresie email pracownika, jeśli są one dostępne w bazie URL.
 - **Generowanie tabel**: Program generuje tabele z podziałem na grupy zawodowe (kadra zarządzająca, kadra kierownicza, pracownicy) oraz wyświetla pracowników z aktualnym, wygasającym i już wygasłym szkoleniem, jeśli użyto flagi `--shell`.
+- **Generowanie list w formacie HTML**: Program generuje osobne listy w formacie HTML dla trzech grup zawodowych:
+   - Kadra zarządzająca
+   - Kadra kierownicza
+   - Pracownicy
+   
+   Listy są zapisywane w katalogu output/lists/.
 
 ## Przykład działania
-Po uruchomieniu programu:
+
+1. Konwersja danych z pliku CSV:
    ```python
    python3 edumonitor.py --csv <ścieżka do pliku CSV> --shell
+   ```
+
+2. Wyświetlanie danych w konsoli:
+   ```python
+   python3 edumonitor.py --shell
    ```
 
    ```sql
@@ -46,6 +65,17 @@ Po uruchomieniu programu:
    | WAYNE        | BRUCE    |   DC  | Security awareness | 26.06.2023     | 24.06.2024 |
    +--------------+----------+-------+--------------------+----------------+------------+
    ```
+
+3. Generowanie list pracowników w formacie HTML:
+   ```python
+   python3 edumonitor.py --generate-training-lists
+   ```
+
+   Po uruchomieniu polecenia program wygeneruje trzy osobne listy:
+
+   - kadra_zarzadzajaca_lista.html
+   - kadra_kierownicza_lista.html
+   - pracownicy_lista.html
 
 ## Plik konfiguracyjny
 W projekcie znajduje się przykładowy plik konfiguracyjny `config/config_example.ini`. Skopiuj ten plik, zmień nazwę na `config.ini`, a następnie dostosuj go do swoich potrzeb, wprowadzając odpowiednie ścieżki oraz URL do pobierania danych:

--- a/config/config_example.ini
+++ b/config/config_example.ini
@@ -19,5 +19,4 @@ HTML_REPORTS = output/reports/
 [DATABASE]
 # URL do pobierania danych o pracownikach
 URL = https://example.com/data
-#
 VERIFY_SSL = True

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -28,6 +28,13 @@
     - Jeżeli program zostanie uruchomiony z flagą `--shell`, moduł `table_display.py` wyświetla wyniki w formie tabeli w konsoli.
     - Pracownicy są grupowani na kadry zarządzające, kierownicze oraz pozostałych, a każda grupa jest podzielona według statusu ważności szkolenia: aktualne, zbliżające się do wygaśnięcia, przeterminowane.
 
+6. **Wyświetlanie wyników w konsoli (opcjonalne):**
+    - Jeżeli program zostanie uruchomiony z flagą `--generate-training-lists`, moduł html_list_generator.py generuje osobne listy w formacie HTML dla każdej grupy zawodowej:
+      - Kadra Zarządzająca
+      - Kadra Kierownicza
+      - Pracownicy
+      > Listy są zapisywane w katalogu `output/lists/`.
+
 ## Moduły w projekcie
 
 ### 1. `csv_loader.py`
@@ -70,17 +77,23 @@
   - Grupuje pracowników według stanowisk oraz statusu ważności szkolenia.
   - Wyświetla dane w formie tabeli, uwzględniając dodatkowe informacje o pracowniku, takie jak `stanowisko` i `email`, jeśli dane te są dostępne z bazy URL.
 
-### 7. `logger_setup.py`
+### 7. `html_list_generator.py`
+- **Opis**: Moduł odpowiedzialny za generowanie list pracowników w formacie HTML.
+- **Funkcjonalności**:
+  - Generuje osobne listy dla różnych grup zawodowych (kadra zarządzająca, kadra kierownicza, pracownicy).
+  - Listy są zapisywane w katalogu `output/lists/`.
+
+### 8. `logger_setup.py`
 - **Opis**: Moduł odpowiedzialny za konfigurację loggera.
 - **Funkcjonalności**:
   - Umożliwia logowanie informacji, ostrzeżeń oraz błędów do pliku i konsoli.
   - Logi są zapisywane w pliku z timestampem, co ułatwia analizę działania programu.
   - Podczas testów logger może być mockowany, aby wyciszyć zbędne komunikaty.
 
-### 8. `arg_parser.py`
+### 9. `arg_parser.py`
 - **Opis**: Moduł odpowiedzialny za obsługę argumentów z linii komend.
 - **Funkcjonalności**:
-  - Umożliwia uruchomienie programu z flagami `--csv`, `--shell`, `--lists-html`, oraz `--report-html`, co pozwala na różne tryby pracy programu.
+  - Umożliwia uruchomienie programu z flagami `--csv`, `--shell`, `--generate-training-lists`, co pozwala na różne tryby pracy programu.
   - Obsługuje argumenty dla ścieżki do pliku CSV oraz wyświetlania danych w konsoli w formie tabeli.
 
 ## Przykładowy przepływ danych
@@ -104,3 +117,7 @@
 
 4. **Wyświetlenie wyników w konsoli**:
     - Jeśli użyto flagi `--shell`, dane są wyświetlane w formie tabeli z dodatkowymi informacjami o pracownikach, takimi jak `stanowisko`, `email` oraz flaga `db_url`, wskazująca, czy pracownik został znaleziony w bazie URL.
+
+5. **Generowanie list pracowników w formacie HTML:**:
+    - Jeśli użyto flagi `--generate-training-lists`, generowane są osobne listy dla kadry zarządzającej, kadry kierowniczej oraz pracowników, zapisywane w katalogu `output/lists/`.
+    

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -25,6 +25,7 @@ edumonitor/
 |   ├── employee_management.py
 |   ├── employee.py
 |   ├── html_generator.py
+|   ├── html_list_generator.py
 |   ├── json_loader.py
 |   ├── logger_setup.py
 |   └── table_display.py

--- a/edumonitor.py
+++ b/edumonitor.py
@@ -1,12 +1,12 @@
 """ edumonitor.py """
 
-import os
 from src.logger_setup import setup_logger
 from src.arg_parser import get_arguments, process_csv_argument
 from src.json_loader import JSONLoader
 from src.table_display import TableDisplay
 from src.employee_management import EmployeeManager
 from src.db_fetcher import DBFetcher
+from src.html_list_generator import HTMLListGenerator
 
 def main():
     logger = setup_logger()
@@ -19,39 +19,46 @@ def main():
     json_loader = JSONLoader()
     db_fetcher = DBFetcher()
     table_display = TableDisplay()
+    list_generator = HTMLListGenerator()
 
     employees_json = None
-    employees_db = []  # Domyślna pusta lista dla danych z URL
+    employees_db = []
 
+    # Jeśli podano --csv, przetwarzamy plik CSV i zapisujemy dane do JSON
     if args.csv:
-        # Przetwarzanie pliku CSV
+        logger.info(f"Przetwarzanie pliku CSV: {args.csv}")
         filtered_data = process_csv_argument(args.csv)
         if filtered_data:
-            # Pobranie danych z bazy URL
-            employees_db = db_fetcher.fetch_employee_data_from_url()
-
-            # Konwersja przefiltrowanych danych na obiekty Employee
+            # Konwersja CSV na strukturę JSON i zapisanie do pliku
             employees_json = json_loader.convert_to_json_structure(filtered_data)
-
-            # Porównanie z danymi z bazy URL
-            if employees_json and employees_db:
-                manager = EmployeeManager(employees_json, employees_db)
-                employees_json = manager.check_employee_in_db()
-
-            # Zapis zaktualizowanych danych do JSON
             json_loader.save_to_json(employees_json)
         else:
+            logger.error("Nie udało się przetworzyć pliku CSV.")
             return
 
-    elif args.shell:
-        # Ładowanie pracowników z najnowszego JSON
+    # Jeśli podano --shell lub --generate-training-lists, ładujemy najnowszy plik JSON
+    if args.shell or args.generate_training_lists:
+        logger.info("Ładowanie danych z najnowszego pliku JSON.")
         employees_json = json_loader.load_employees_from_json()
 
-    # Wyświetlanie wyników w tabeli, jeśli są dane do wyświetlenia
+    # Jeśli podano flagę --shell, wyświetlamy dane w konsoli
     if args.shell and employees_json:
+        logger.info("Wyświetlanie danych w trybie interaktywnym.")
+        employees_db = db_fetcher.fetch_employee_data_from_url()
         manager = EmployeeManager(employees_json, employees_db)
         kadra_zarzadcza, kadra_kierownicza, pracownicy = manager.filter_by_position()
         table_display.display_all_groups(kadra_zarzadcza, kadra_kierownicza, pracownicy)
+
+    # Jeśli podano flagę --generate-training-lists, generujemy listy dla każdej grupy zawodowej
+    if args.generate_training_lists and employees_json:
+        logger.info("Generowanie list pracowników w formacie HTML.")
+        employees_db = db_fetcher.fetch_employee_data_from_url()
+        manager = EmployeeManager(employees_json, employees_db)
+        employees_json = manager.check_employee_in_db()
+
+        # Filtrowanie pracowników na grupy zawodowe i generowanie list
+        kadra_zarzadcza, kadra_kierownicza, pracownicy = manager.filter_by_position()
+        list_generator.generate_lists_for_all_groups(kadra_zarzadcza, kadra_kierownicza, pracownicy)
 
     logger.info("Program EduMonitor zakończył działanie.")
 

--- a/src/arg_parser.py
+++ b/src/arg_parser.py
@@ -11,8 +11,7 @@ def get_arguments():
     parser = argparse.ArgumentParser(description='EduMonitor - wczytaj plik CSV i wyświetl dane.')
     parser.add_argument('--csv', type=str, help='Ścieżka do pliku CSV, który zostanie zapisany jako JSON')
     parser.add_argument('--shell', action='store_true', help='Wyświetlenie wyników w konsoli (tabele)')
-    parser.add_argument('--lists-html', action='store_true', help='Generowanie list pracowników w formacie HTML')
-    parser.add_argument('--report-html', action='store_true', help='Generowanie raportu o stanie wyszkolenia w formacie HTML')
+    parser.add_argument('--generate-training-lists', action='store_true', help='Generowanie listy pracowników na szkolenia w formacie HTML')
 
     return parser.parse_args()
 

--- a/src/html_list_generator.py
+++ b/src/html_list_generator.py
@@ -1,0 +1,53 @@
+""" src/html_list_generator.py """
+
+import os
+from jinja2 import Template
+from src.config_loader import ConfigLoader
+from src.logger_setup import setup_logger
+
+logger = setup_logger()
+
+class HTMLListGenerator:
+    def __init__(self, config_file='config/config.ini'):
+        self.config_loader = ConfigLoader(config_file)
+        self.lists_dir = self.config_loader.get_output_lists_dir()
+        self.templates_dir = 'templates'
+        self.employee_list_template = self.load_template('employee_list_template.html')
+
+    def load_template(self, template_name):
+        """Ładuje szablon HTML."""
+        template_path = os.path.join(self.templates_dir, template_name)
+        try:
+            with open(template_path, 'r', encoding='utf-8') as file:
+                template_content = file.read()
+            return Template(template_content)
+        except FileNotFoundError:
+            logger.error(f"Plik szablonu {template_path} nie został znaleziony.")
+            return None
+
+    def generate_employee_list(self, group_name, employees):
+        """Generuje listę pracowników w formacie HTML dla jednej grupy."""
+        if not employees:
+            logger.info(f"Brak pracowników w grupie '{group_name}'.")
+            return
+
+        if not self.employee_list_template:
+            logger.error("Szablon listy pracowników nie został poprawnie załadowany.")
+            return
+
+        file_name = f"{group_name.lower().replace(' ', '_')}_lista.html"
+        file_path = os.path.join(self.lists_dir, file_name)
+        html_content = self.employee_list_template.render(group_name=group_name, employees=employees)
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+        logger.info(f"Lista pracowników '{group_name}' zapisana w {file_path}")
+
+    def generate_lists_for_all_groups(self, kadra_zarzadcza, kadra_kierownicza, pracownicy):
+        """Generuje listy dla wszystkich grup zawodowych."""
+        if kadra_zarzadcza:
+            self.generate_employee_list('Kadra Zarządzająca', kadra_zarzadcza)
+        if kadra_kierownicza:
+            self.generate_employee_list('Kadra Kierownicza', kadra_kierownicza)
+        if pracownicy:
+            self.generate_employee_list('Pracownicy', pracownicy)

--- a/templates/employee_list_template.html
+++ b/templates/employee_list_template.html
@@ -127,7 +127,7 @@
         <tr>
             <td>{{ loop.index }}</td>
             <td>{{ employee.nazwisko }} {{ employee.imie }}</td>
-            <td>{{ employee.jednostka }}</td>
+            <td>{{ employee.jednostka_organizacyjna }}</td>
             <td class="signature"></td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
W tym pull request wprowadzono następujące zmiany:

1. Nowe funkcjonalności:
    - Generowanie osobnych list pracowników w formacie HTML dla grup zawodowych:
        - Kadra Zarządzająca
        - Kadra Kierownicza
        - Pracownicy
    - Listy generowane są na podstawie danych z pliku CSV, a następnie zapisywane w katalogu `output/lists/`.

2. Zmiany w strukturze projektu:
    - Wprowadzono nowy moduł `html_list_generator.py`, odpowiedzialny za generowanie list HTML.
    - Zaktualizowano główną funkcję w `edumonitor.py`, aby korzystała z metody generowania list z nowego modułu.
    - Uproszczono logikę obsługi flag `--csv`, `--shell` i `--generate-training-lists`.

3. Zaktualizowano dokumentację:
    - Dodano szczegóły dotyczące nowych funkcjonalności do plików dokumentacyjnych, w tym opis generowania list pracowników w formacie HTML.
    - Zaktualizowano sekcje dotyczące przepływu danych, flag oraz modułów w projekcie.
    - Dodano przykładowy przepływ danych, uwzględniając generowanie list w formacie HTML.

Zamknięte Issue:
- Issue związane z generowaniem osobnych list dla grup zawodowych oraz aktualizacją dokumentacji można uznać za zamknięte.

closed #21 